### PR TITLE
Add committing alternation operator `else` (parser, engine, docs, tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,37 @@ In objects:
 { (! secret:_) .. }         // assert no key named 'secret' exists
 ```
 
+## Committing alternation (`else`)
+
+`A else B` is a **discriminator over solutions**. It keeps all solutions from `A`, plus only those solutions from `B` whose **interface projection** does not appear in `A`.
+
+Formally:
+
+```
+Sol(A else B) =
+  Sol(A)
+  ∪ { s ∈ Sol(B) | ¬∃ s' ∈ Sol(A) such that π_I(s) = π_I(s') }
+```
+
+Where `I` is the **interface variables** of the construct: variables that are visible outside of `(A else B)` (i.e. variables that also appear elsewhere in the pattern).
+
+This makes `else` commutative with surrounding predicates while still being non-commutative itself: `(A else B) ≠ (B else A)`.
+
+```javascript
+// Safe schema fallback (order-independent)
+{ p:$x  q:($x else 2) }  // matches {p:1,q:2} with x=1
+{ q:($x else 2)  p:$x }  // same result
+```
+
+**Syntax rule:** `else` has the same precedence as `|`, and you cannot mix them without parentheses:
+
+```
+A | B else C     // error
+A else B | C     // error
+A | (B else C)   // ok
+(A | B) else C   // ok
+```
+
 ## Precedence
 
 **High to low:**
@@ -541,7 +572,7 @@ In objects:
 2. Optional `?`, quantifiers `+`, `*`, etc.
 3. Breadcrumb operators `.`, `..`, `[]`
 4. Adjacency/commas (in arrays and objects)
-5. Alternation `|`
+5. Alternation `|` and `else` (same precedence; do not mix without parentheses)
 6. Key-value separator `:`, `:>`
 
 Parentheses override precedence. Lookaheads always require parentheses.

--- a/test/else.test.js
+++ b/test/else.test.js
@@ -1,0 +1,36 @@
+/**
+ * Else operator tests
+ *
+ * Run with: node test/else.test.js
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Tendril } from '../src/tendril-api.js';
+
+function extractAll(pattern, data) {
+  return Tendril(pattern).match(data).solutions().toArray().map(s => s.toObject());
+}
+
+function matches(pattern, data) {
+  return Tendril(pattern).match(data).hasMatch();
+}
+
+test('else picks fallback when A has no interface match, regardless of order', () => {
+  const data = {p: 1, q: 2};
+  assert.deepEqual(extractAll('{ p:$x q:($x else 2) }', data), [{x: 1}]);
+  assert.deepEqual(extractAll('{ q:($x else 2) p:$x }', data), [{x: 1}]);
+});
+
+test('else excludes B when A matches the same interface projection', () => {
+  const data = {p: 1, q: 1};
+  assert.deepEqual(extractAll('{ p:$x q:($x else 1) }', data), [{x: 1}]);
+});
+
+test('else works in arrays', () => {
+  assert.ok(matches('[1 else 2]', [2]));
+  assert.ok(matches('[1 else 2]', [1]));
+  assert.ok(!matches('[1 else 2]', [3]));
+});
+
+console.log('\n✓ All else tests defined\n');

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -68,4 +68,9 @@ test('remainder quantifier - negative should throw', () => {
   assert.throws(() => parsePattern('{ a:b %#{-2} }'));
 });
 
+test('cannot mix | and else without parentheses', () => {
+  assert.throws(() => parsePattern('a|b else c'));
+  assert.throws(() => parsePattern('a else b|c'));
+});
+
 console.log('\n✓ All parser tests defined\n');


### PR DESCRIPTION
### Motivation

- Introduce a declarative, solution-discriminating alternation `else` that prefers `A` over `B` per interface-projection equivalence class.  
- Ensure `else` has the same precedence as `|` but forbid mixing `|` and `else` without parentheses to avoid ambiguous parses.  
- Make `else` commutative with surrounding predicates while keeping `(A else B) ≠ (B else A)`.  
- Provide user-facing documentation and test coverage for the new operator.

### Description

- Added an `Else` AST node and parsing support so `ITEM := Term (('|' | 'else') Term)*` with `peekAltOp`, `eatAltOp`, and `chainElse`, plus a guard to error on mixing `|` and `else` without parentheses.  
- Implemented engine semantics in `matchItem` to enumerate `A` and `B` solutions, compute interface variables via `countVars`/`getInterfaceVars`, project solutions, and emit all `A` solutions plus only those `B` solutions whose interface projection is not present in `A` (using `deepEqual` for projection comparison).  
- Fixed binding parsing edge-cases with `isBindingStart` to correctly detect `($x=...)` and `(@x=...)` forms and updated `patternHasBindings` to traverse `left`/`right` nodes.  
- Documented `else` in `README.md` (semantics and precedence) and added tests `test/else.test.js` plus a parser test asserting that mixing `|` and `else` without parentheses errors.

### Testing

- Ran `node test/else.test.js` which passed all tests verifying order-independence, exclusion of shadowed `B` solutions, and array usage.  
- Ran `node test/parser.test.js` which passed and includes the new parse-error checks for mixing `|` and `else`.  
- No automated tests failed during the rollout; the initial failing parser case was fixed by adding `isBindingStart` checks.  
- Tests exercise parsing, engine matching, and README-updated behavior for the new operator.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d825bd2c4833096aca99cbefca5a5)